### PR TITLE
{#103} expired error status 500 -> 401

### DIFF
--- a/gift/src/main/kotlin/msa/gift/common/jwt/AuthenticationManager.kt
+++ b/gift/src/main/kotlin/msa/gift/common/jwt/AuthenticationManager.kt
@@ -16,7 +16,13 @@ class AuthenticationManager(
 
     override fun authenticate(authentication: Authentication): Mono<Authentication> {
         val authToken = authentication.credentials.toString()
-        val username = jwtUtil.getUsernameFromToken(authToken)
+        var username: String?
+        try {
+            username = jwtUtil.getUsernameFromToken(authToken)
+        } catch (e: Exception) {
+            return Mono.empty()
+        }
+
         return Mono.just(jwtUtil.validateToken(authToken))
             .filter { valid -> valid }
             .switchIfEmpty(Mono.empty())

--- a/gift/src/main/kotlin/msa/gift/common/jwt/SecurityContextRepository.kt
+++ b/gift/src/main/kotlin/msa/gift/common/jwt/SecurityContextRepository.kt
@@ -19,17 +19,32 @@ class SecurityContextRepository(
     }
 
     override fun load(swe: ServerWebExchange): Mono<SecurityContext> {
-        return Mono.justOrEmpty(swe.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
-            .filter { authHeader: String ->
-                authHeader.startsWith(
-                    "Bearer "
-                )
-            }
-            .flatMap { authHeader: String ->
-                val authToken = authHeader.substring(7)
-                val auth: Authentication =
-                    UsernamePasswordAuthenticationToken(authToken, authToken)
-                authenticationManager.authenticate(auth).map { SecurityContextImpl(it) }
-            }
+//        return Mono.justOrEmpty(swe.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
+//            .filter { authHeader: String ->
+//                authHeader.startsWith(
+//                    "Bearer "
+//                )
+//            }
+//            .flatMap { authHeader: String ->
+//                val authToken = authHeader.substring(7)
+//                val auth: Authentication =
+//                    UsernamePasswordAuthenticationToken(authToken, authToken)
+//                authenticationManager.authenticate(auth).map { SecurityContextImpl(it) }
+//            }
+
+        val request = swe.request
+        val authHeader = request.headers.getFirst(HttpHeaders.AUTHORIZATION)
+        var authToken: String? = null
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            authToken = authHeader.substring(7)
+        }
+
+        if (authToken != null) {
+            val auth: Authentication = UsernamePasswordAuthenticationToken(authToken, authToken)
+            val authentication = authenticationManager.authenticate(auth)
+            return authentication.map { SecurityContextImpl(it) }
+        }
+        return Mono.empty()
     }
 }

--- a/gift/src/main/kotlin/msa/gift/common/jwt/WebSecurityConfig.kt
+++ b/gift/src/main/kotlin/msa/gift/common/jwt/WebSecurityConfig.kt
@@ -22,24 +22,28 @@ class WebSecurityConfig(
     fun securitygWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
         return http
             .exceptionHandling()
-            .authenticationEntryPoint { swe: ServerWebExchange, e: AuthenticationException? ->
+            .authenticationEntryPoint { swe: ServerWebExchange, _: AuthenticationException? ->
                 Mono.fromRunnable { swe.response.statusCode = HttpStatus.UNAUTHORIZED }
-            }.accessDeniedHandler { swe: ServerWebExchange, e: AccessDeniedException? ->
+            }.accessDeniedHandler { swe: ServerWebExchange, _: AccessDeniedException? ->
                 Mono.fromRunnable { swe.response.statusCode = HttpStatus.FORBIDDEN }
-            }.and()
+            }
+
+            .and()
+
             .csrf().disable()
             .formLogin().disable()
             .httpBasic().disable()
+
             .authenticationManager(authenticationManager)
             .securityContextRepository(securityContextRepository)
+
             .authorizeExchange()
             .pathMatchers(HttpMethod.OPTIONS).permitAll()
-            .pathMatchers(
-                "/api/v1/auth/login",
-                "/api/v1/auth/reissue",
-                "/api/v1/user"
-            ).permitAll()
+            .pathMatchers("/api/v1/auth/login").permitAll()
             .anyExchange().authenticated()
-            .and().build()
+
+            .and()
+
+            .build()
     }
 }

--- a/order/http-test/auth-api.http
+++ b/order/http-test/auth-api.http
@@ -24,6 +24,19 @@ Content-Type: application/json
  client.global.set("orderRefreshToken", response.body.data.refreshToken);
  %}
 
+### 어드민 인증
+POST http://localhost:8080/api/v1/auth/login
+Content-Type: application/json
+
+{
+  "loginId": "admin",
+  "password": "admin"
+}
+> {%
+ client.global.set("orderAccessToken", response.body.data.accessToken);
+ client.global.set("orderRefreshToken", response.body.data.refreshToken);
+ %}
+
 ### 토큰 재발행
 POST http://localhost:8080/api/v1/auth/reissue
 Content-Type: application/json

--- a/order/src/main/kotlin/msa/order/common/jwt/AuthenticationManager.kt
+++ b/order/src/main/kotlin/msa/order/common/jwt/AuthenticationManager.kt
@@ -13,10 +13,15 @@ class AuthenticationManager(
     val jwtUtil: JwtUtil
 ) : ReactiveAuthenticationManager {
 
-
     override fun authenticate(authentication: Authentication): Mono<Authentication> {
         val authToken = authentication.credentials.toString()
-        val username = jwtUtil.getUsernameFromToken(authToken)
+        var username: String?
+        try {
+            username = jwtUtil.getUsernameFromToken(authToken)
+        } catch (e: Exception) {
+            return Mono.empty()
+        }
+
         return Mono.just(jwtUtil.validateToken(authToken))
             .filter { valid -> valid }
             .switchIfEmpty(Mono.empty())

--- a/order/src/main/kotlin/msa/order/common/jwt/SecurityContextRepository.kt
+++ b/order/src/main/kotlin/msa/order/common/jwt/SecurityContextRepository.kt
@@ -19,17 +19,32 @@ class SecurityContextRepository(
     }
 
     override fun load(swe: ServerWebExchange): Mono<SecurityContext> {
-        return Mono.justOrEmpty(swe.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
-            .filter { authHeader: String ->
-                authHeader.startsWith(
-                    "Bearer "
-                )
-            }
-            .flatMap { authHeader: String ->
-                val authToken = authHeader.substring(7)
-                val auth: Authentication =
-                    UsernamePasswordAuthenticationToken(authToken, authToken)
-                authenticationManager.authenticate(auth).map { SecurityContextImpl(it) }
-            }
+//        return Mono.justOrEmpty(swe.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
+//            .filter { authHeader: String ->
+//                authHeader.startsWith(
+//                    "Bearer "
+//                )
+//            }
+//            .flatMap { authHeader: String ->
+//                val authToken = authHeader.substring(7)
+//                val auth: Authentication =
+//                    UsernamePasswordAuthenticationToken(authToken, authToken)
+//                authenticationManager.authenticate(auth).map { SecurityContextImpl(it) }
+//            }
+
+        val request = swe.request
+        val authHeader = request.headers.getFirst(HttpHeaders.AUTHORIZATION)
+        var authToken: String? = null
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            authToken = authHeader.substring(7)
+        }
+
+        if (authToken != null) {
+            val auth: Authentication = UsernamePasswordAuthenticationToken(authToken, authToken)
+            val authentication = authenticationManager.authenticate(auth)
+            return authentication.map { SecurityContextImpl(it) }
+        }
+        return Mono.empty()
     }
 }

--- a/order/src/main/kotlin/msa/order/common/jwt/WebSecurityConfig.kt
+++ b/order/src/main/kotlin/msa/order/common/jwt/WebSecurityConfig.kt
@@ -22,24 +22,28 @@ class WebSecurityConfig(
     fun securitygWebFilterChain(http: ServerHttpSecurity): SecurityWebFilterChain {
         return http
             .exceptionHandling()
-            .authenticationEntryPoint { swe: ServerWebExchange, e: AuthenticationException? ->
+            .authenticationEntryPoint { swe: ServerWebExchange, _: AuthenticationException? ->
                 Mono.fromRunnable { swe.response.statusCode = HttpStatus.UNAUTHORIZED }
-            }.accessDeniedHandler { swe: ServerWebExchange, e: AccessDeniedException? ->
+            }.accessDeniedHandler { swe: ServerWebExchange, _: AccessDeniedException? ->
                 Mono.fromRunnable { swe.response.statusCode = HttpStatus.FORBIDDEN }
-            }.and()
+            }
+
+            .and()
+
             .csrf().disable()
             .formLogin().disable()
             .httpBasic().disable()
+
             .authenticationManager(authenticationManager)
             .securityContextRepository(securityContextRepository)
+
             .authorizeExchange()
             .pathMatchers(HttpMethod.OPTIONS).permitAll()
-            .pathMatchers(
-                "/api/v1/auth/login",
-                "/api/v1/auth/reissue",
-                "/api/v1/user"
-            ).permitAll()
+            .pathMatchers("/api/v1/auth/login").permitAll()
             .anyExchange().authenticated()
-            .and().build()
+
+            .and()
+
+            .build()
     }
 }


### PR DESCRIPTION
```kotlin
try {
    username = jwtUtil.getUsernameFromToken(authToken)
} catch (e: Exception) {
    return Mono.empty()
}
```

- getUsernameFromToken에서 오류가 발생했을 때 오류를 내뱉는데, 그것을 throw하거나 Mono.error로 던져도 500에러로 뜬다.
- 일단 Mono.empty()로 하면 401로 status가 변하는데,
- ControllerAdvice에서는 여전히 catch가 안된다. 
- controllerAdvice에서 catch가 안되는 점은 급한 사항은 아니니 추후에 알아보도록 하자.